### PR TITLE
Adding encoding directive so the copyright symbol doesn't cause problems

### DIFF
--- a/Microservices/scripts/SMI/handlers/VirtualIdentityMicroservice.py
+++ b/Microservices/scripts/SMI/handlers/VirtualIdentityMicroservice.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 Copyright © 2017 DELL Inc. or its subsidiaries.  All Rights Reserved.
 Created on May 4, 2017

--- a/Microservices/scripts/SMI/handlers/VirtualNetworkMicroservice.py
+++ b/Microservices/scripts/SMI/handlers/VirtualNetworkMicroservice.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 '''
+Copyright © 2017 DELL Inc. or its subsidiaries.  All Rights Reserved.
 Created on May 2, 2017
 
 @author: Michael Regert, Michael Hepfer

--- a/Microservices/scripts/SMI/tests/virtualIdentityTest.py
+++ b/Microservices/scripts/SMI/tests/virtualIdentityTest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 Copyright © 2017 DELL Inc. or its subsidiaries.  All Rights Reserved.
 Created on May 4, 2017

--- a/Microservices/scripts/SMI/tests/virtualNetworkTest.py
+++ b/Microservices/scripts/SMI/tests/virtualNetworkTest.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 '''
+Copyright © 2017 DELL Inc. or its subsidiaries.  All Rights Reserved.
 Created on May 2, 2017
 
 @author: Michael Regert, Michael Hepfer


### PR DESCRIPTION
Adding encoding directive so the copyright statement doesn't cause problems when running on linux.